### PR TITLE
return previous cookie instead of new one

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,6 @@
             return null;
         }
 
-        function isWebView() {
-            const userAgent = navigator.userAgent || navigator.vendor || window.opera;
-            const iosWebView = /AppleWebKit(?!.*Safari)/i.test(userAgent);
-            return iosWebView;
-        }
-
         function getCurrentTimestamp() {
             const now = new Date();
             const hours = now.getHours().toString().padStart(2, '0');
@@ -38,24 +32,12 @@
         }
 
         window.onload = function() {
-            // Get values
-            const token = getCookie('token');
-            const userUuid = sessionStorage.getItem('userUuid');
-
-            // If not in a webview, set cookie with timestamp and sessionStorage
-            if (!isWebView()) {
-                if (!token) {
-                    const timestamp = getCurrentTimestamp();
-                    setCookie('token', timestamp, 1);
-                }
-                if (!userUuid) sessionStorage.setItem('userUuid', 'XYZ');
-            }
+            const oldCookie = getCookie('cookie');            
+            setCookie('cookie', getCurrentTimestamp(), 1);
 
             // Redirect to the custom URL scheme
-            const redirectToken = getCookie('token');
-            const redirectUserUuid = sessionStorage.getItem('userUuid');
-            if (redirectToken && redirectUserUuid) {
-                window.location.href = `x-example-app://callback?token=${redirectToken}&userUuid=${redirectUserUuid}`;
+            if (oldCookie) {
+                window.location.href = `x-example-app://callback?previous-cookie=${oldCookie}`;
             }
         }
     </script>

--- a/index.html
+++ b/index.html
@@ -6,10 +6,7 @@
     <title>Session Sharing Test</title>
     <script>
         function setCookie(name, value, days) {
-            const d = new Date();
-            d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
-            const expires = "expires=" + d.toUTCString();
-            document.cookie = name + "=" + value + "; expires=" + expires + ";path=/";
+            document.cookie = name + "=" + value + ";max-age=31536000";
         }
 
         function getCookie(name) {
@@ -44,6 +41,6 @@
 </head>
 <body>
     <h1>Session Sharing Test</h1>
-    <p>If you see this page, the redirect didn't work.</p>
+    <p>If you are stuck on this page, the redirect didn't work.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             const d = new Date();
             d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
             const expires = "expires=" + d.toUTCString();
-            document.cookie = name + "=" + value + ";" + expires + ";path=/";
+            document.cookie = name + "=" + value + "; expires=" + expires + ";path=/";
         }
 
         function getCookie(name) {


### PR DESCRIPTION
`isWebView()` wasn't working because the auth session isn't in a UIWebView, it's in an actual browser instance launched by the system.

By returning the _previous_ token's value, you don't need to check if you're in the actual browser or in the app's auth browser, you can just always set the cookies. Then you can tell from the timestamp when the _previous_ cookie was created, which will indicate _where_ it was created (so we can tell if it's shared across sessions)

Examples:

First time
1. open browser, won't redirect
2. open app's web auth

Expected (if shared): will redirect with timestamp of step 1
If it doesn't work: won't redirect (we'd still want to troubleshoot `setCookie()`)

Subsequent time
1. open app's web auth, note time
2. open browser, note time
3. open app's web auth again

Expected (if shared): will output timestamp of step 2
If it doesn't work: will output timestamp of step 1 (we'd still want to troubleshoot `setCookie()`)